### PR TITLE
_old_instance is serialized at the time of assignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "signalhooks"
-version = "0.1.4"
+version = "0.1.5"
 description = "Set of useful hooks that you can attach to your Django Signals to notify other services when a Signal is triggered"
 authors = ["Martin Zugnoni <martin.zugnoni@gmail.com>"]
 

--- a/signalhooks/hooks.py
+++ b/signalhooks/hooks.py
@@ -127,12 +127,9 @@ class SNSSignalHook(SignalHook):
         if not created and hasattr(instance, "_old_instance"):
             messageAttributes["OldInstance"] = {
                 "DataType": "String",
-                "StringValue": self.serialize_instance(
-                    instance._old_instance,
-                    serializer=self.serializer,
-                    nested_fields=self.nested_fields,
-                    max_depth=self.max_depth,
-                ),
+                "StringValue": base64.b64encode(
+                    instance._old_instance.encode("utf-8")
+                ).decode("utf-8"),
             }
 
         return messageAttributes

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -113,9 +113,6 @@ class SNSSignalHookTestCase(BaseHooksTestCase):
 
         instance = FakeModel()
         instance.name = "Neapolitan"
-        _old_instance = FakeModel()
-        _old_instance.name = "Siciliana"
-        instance._old_instance = FakeModel()
         post_save.send(instance=instance, sender=FakeModel, created=False)
 
         msg = sqs_client.receive_message(QueueUrl=queue_url)
@@ -130,10 +127,6 @@ class SNSSignalHookTestCase(BaseHooksTestCase):
                 "Instance": {
                     "Type": "String",
                     "Value": "eyJtb2RlbCI6ICJ0ZXN0cy5mYWtlbW9kZWwiLCAicGsiOiBudWxsLCAiZmllbGRzIjogeyJuYW1lIjogIk5lYXBvbGl0YW4ifX0=",
-                },
-                "OldInstance": {
-                    "Type": "String",
-                    "Value": "eyJtb2RlbCI6ICJ0ZXN0cy5mYWtlbW9kZWwiLCAicGsiOiBudWxsLCAiZmllbGRzIjogeyJuYW1lIjogIiJ9fQ==",
                 },
             },
         )


### PR DESCRIPTION
This is to make sure that related properties, many-to-many in particular, have the expected values